### PR TITLE
Add basic filters and .ics export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 .idea/
+
 venv/
 .venv/
-*.txt
+
 **/__pycache__/
 **/*.egg-info/
+
+*.txt
+*.ics

--- a/find_time/classes.py
+++ b/find_time/classes.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from enum import Enum
-from typing import Union, Self, Set
+from typing import Union, Self, Set, Iterable, Tuple
 
 
 class Day(Enum):
@@ -34,6 +34,11 @@ def str_to_day(s: str) -> Day:
 def str_to_time(s: str) -> float:
     h, _, m = s.partition(':')
     return float(h) + float(m) / 60
+
+
+def time_to_int(time: float) -> Tuple[int, int]:
+    i, d = divmod(time, 1)
+    return int(i), int(d * 60)
 
 
 class TimeSpan:
@@ -83,6 +88,10 @@ class TimeSpan:
         return f'{int(si):02}:{int(sd * 60):02}'
 
     @property
+    def start_int(self):
+        return time_to_int(self._start)
+
+    @property
     def end(self):
         return self._end
 
@@ -90,6 +99,10 @@ class TimeSpan:
     def end_str(self):
         ei, ed = divmod(self._end, 1)
         return f'{int(ei):02}:{int(ed * 60):02}'
+
+    @property
+    def end_int(self):
+        return time_to_int(self._end)
 
     def contains(self, span: Self) -> bool:
         if span._day != self._day:
@@ -190,8 +203,13 @@ class Person:
         self._availability[span.day].append(span)
         self._availability[span.day].sort(key=lambda x: x.start)
 
-    def availability(self):
-        return self._availability
+    def availability_by_block(self) -> Iterable[TimeSpan]:
+        for day in self._availability.values():
+            for span in day:
+                yield span
+
+    def availability_by_day(self):
+        return self._availability.values()
 
     def is_available(self, span: Union[TimeSpan, EventTime]) -> bool:
         if isinstance(span, EventTime):

--- a/find_time/main.py
+++ b/find_time/main.py
@@ -63,7 +63,7 @@ def main():
         blocks = sorting[sort_type](blocks)
 
     # print all blocks
-    if args.nprint <= 0:
+    if args.nprint < 0:
         args.nprint = None
 
     # print time blocks

--- a/find_time/to_ics.py
+++ b/find_time/to_ics.py
@@ -1,0 +1,71 @@
+import argparse
+from datetime import datetime as dt, timedelta
+from pathlib import Path
+
+from dateutil import tz
+from ics import Calendar, Event
+from ics.grammar.parse import ContentLine
+
+import find_time
+
+date_format = '%Y-%m-%d'
+time_format = '%H:%M'
+
+
+def next_weekday_after_date(weekday: int, date: dt):
+    offset = (weekday - date.isoweekday()) % 7
+    return date + timedelta(offset)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--input', required=True, help='Input file')
+    parser.add_argument('-o', '--output', required=True, help='Output file')
+    parser.add_argument('-s', '--start-date', required=True,
+                        help='Start date: YYYY-MM-DD')
+    parser.add_argument('-e', '--end-date', required=True,
+                        help='End date: YYYY-MM-DD')
+    parser.add_argument('-t', '--timezone', help='Timezone',
+                        default='US/Eastern')
+    args = parser.parse_args()
+
+    # calendar
+    c = Calendar()
+
+    # load people
+    people = find_time.load(args.input)
+
+    # parse start and end date
+    timezone = tz.gettz(args.timezone)
+    start_date = dt.strptime(args.start_date, date_format).replace(
+        tzinfo=timezone)
+    end_date = dt.strptime(args.end_date, date_format).replace(tzinfo=timezone)
+    end_date_str = end_date.astimezone(tz.UTC).strftime('%Y%m%dT%H%M%SZ')
+
+    # add availability to calendar
+    print(f'adding availability')
+    for person in people:
+        for a in person.availability_by_block():
+            d = next_weekday_after_date(a.day.value, start_date)
+            h, m = a.start_int
+            st = d.replace(hour=h, minute=m)
+            h, m = a.end_int
+            et = d.replace(hour=h, minute=m)
+
+            e = Event()
+            e.name = person.name
+            e.begin = st
+            e.end = et
+            e.extra.append(ContentLine(name='RRULE',
+                                       value=f'FREQ=WEEKLY;UNTIL={end_date_str}'))
+            c.events.add(e)
+
+    # write calendar
+    print('writing .ics')
+    with Path(args.output).open('w') as f:
+        f.write(c.serialize())
+    print('done')
+
+
+if __name__ == '__main__':
+    main()

--- a/find_time/utils.py
+++ b/find_time/utils.py
@@ -8,7 +8,7 @@ def print_avail(attendees: Union[Person, Iterable[Person]]):
         attendees = (attendees,)
     for person in attendees:
         print(f'{person.name}:')
-        for day_spans in person.availability().values():
+        for day_spans in person.availability_by_day():
             if len(day_spans) == 0:
                 continue
             day = day_spans[0].day

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+ics
 lark
+python-dateutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,4 @@ include=find_time
 [options.entry_points]
 console_scripts =
     find-time = find_time.main:main
+    avail-to-ics = find_time.to_ics:main


### PR DESCRIPTION
- find-time: Add `minh` and `maxh` filters for reporting time blocks of a certain length:
```shell
# only print blocks that are at least 1 hour long
find-time -i avail.txt --filter minh=1

# only print blocks that are no more than 1 hour long
find-time -i avail.txt --filter maxh=1
```
- **New:** avail-to-ics: command line utility for turning availability files into recurring events in an `.ics`
```shell
# create a calendar which repeats the weekly events in avail.txt from [2024-09-01, 2025-01-01)
avail-to-ics -i avail.txt -o avail.ics --start-date 2024-09-01 --end-date 2025-01-01
```